### PR TITLE
fixed package dependencies

### DIFF
--- a/lwr_bringup/package.xml
+++ b/lwr_bringup/package.xml
@@ -12,16 +12,15 @@
 
   <run_depend>xacro</run_depend>
   <run_depend>lwr_fri</run_depend>
-  <run_depend>lwr_impedance_controller</run_depend>
   <run_depend>oro_joint_state_publisher</run_depend>
   <run_depend>rtt_sensor_msgs</run_depend>
   <run_depend>rtt_geometry_msgs</run_depend>
-  <run_depend>rtt_diagnostics_msgs</run_depend>
+  <run_depend>rtt_diagnostic_msgs</run_depend>
   <run_depend>rtt_control_msgs</run_depend>
   <run_depend>rtt</run_depend>
   <run_depend>rtt_ros</run_depend>
   <run_depend>rtt_rosnode</run_depend>
-  <run_depend>rtt_rostopic</run_depend>
+  <run_depend>rtt_roscomm</run_depend>
   <run_depend>rtt_rosparam</run_depend> 
 
 </package>


### PR DESCRIPTION
lwr_impedance_controller does not exist at all
rtt_rostopic is in rtt_roscomm
rtt_diagnostics is called rtt_diagnostic
